### PR TITLE
De-linuxify bitwise ops

### DIFF
--- a/src/lib/include/casemate-impl.h
+++ b/src/lib/include/casemate-impl.h
@@ -4,6 +4,9 @@
 /* grab public API */
 #include <casemate.h>
 
+/* include platform-specific thingies */
+#include <casemate-impl/platform.h>
+
 /* grab internal APIs */
 #include <casemate-impl/types.h>
 #include <casemate-impl/string.h>

--- a/src/lib/include/casemate-impl/arch.h
+++ b/src/lib/include/casemate-impl/arch.h
@@ -6,8 +6,8 @@
 #define PAGE_SHIFT 12
 #define PAGE_SIZE (1 << PAGE_SHIFT)
 
-#define OFFSET_IN_PAGE(x) (((x) & GENMASK(PAGE_SHIFT - 1, 0)))
-#define PAGE_ALIGN_DOWN(x) ((x) & ~GENMASK(PAGE_SHIFT, 0))
+#define OFFSET_IN_PAGE(x) (((x) & BITMASK(PAGE_SHIFT - 1, 0)))
+#define PAGE_ALIGN_DOWN(x) ((x) & ~BITMASK(PAGE_SHIFT - 1, 0))
 #define PAGE_ALIGN(x) PAGE_ALIGN_DOWN(((x)+PAGE_SIZE-1))
 #define IS_PAGE_ALIGNED(x) (OFFSET_IN_PAGE(x) == 0)
 

--- a/src/lib/include/casemate-impl/asserts.h
+++ b/src/lib/include/casemate-impl/asserts.h
@@ -1,11 +1,11 @@
 #ifndef CASEMATE_ASSERTS_H
 #define CASEMATE_ASSERTS_H
 
-#ifndef __KVM_NVHE_HYPERVISOR__
 #include <casemate-impl/options.h>
 #include <casemate-impl/printer.h>
 #include <casemate-impl/model.h>
 
+#ifndef CONFIG_HAS_ASSERT
 #define ghost_assert(expr) \
 	if (!(expr)) { \
 		GHOST_WARN(#expr); \
@@ -32,18 +32,6 @@
 	ghost_assert(false); \
 	__builtin_unreachable(); \
 } while (0);
-
-#else
-
-#include <nvhe/ghost/ghost_context.h>
-#include <nvhe/ghost/ghost_asserts.h>
-
-#define GHOST_MODEL_CATCH_FIRE(msg) { \
-	ensure_traced_current_transition(true); \
-	GHOST_WARN(msg); \
-	ghost_assert(false); \
-}
-
-#endif
+#endif /* CONFIG_HAS_ASSERT */
 
 #endif /* CASEMATE_ASSERTS_H */

--- a/src/lib/include/casemate-impl/bitwise.h
+++ b/src/lib/include/casemate-impl/bitwise.h
@@ -1,12 +1,9 @@
 #ifndef BITWISE_H
 #define BITWISE_H
 
-#ifndef __KVM_NVHE_HYPERVISOR__
+#ifndef CONFIG_HAS_BITWISE
 #define BIT(I) (1UL << (I))
 #define BITMASK(HI, LO) (((1UL << ((HI) - (LO) + 1)) - 1UL) << (LO))
-#else
-#include <linux/bits.h>
-#define BITMASK(HI, LO) GENMASK(HI, LO)
-#endif
+#endif /* CONFIG_HAS_BITWISE */
 
 #endif /* BITWISE_H */

--- a/src/lib/include/casemate-impl/bitwise.h
+++ b/src/lib/include/casemate-impl/bitwise.h
@@ -3,9 +3,10 @@
 
 #ifndef __KVM_NVHE_HYPERVISOR__
 #define BIT(I) (1UL << (I))
-#define GENMASK(HI, LO) (((1UL << ((HI) - (LO) + 1)) - 1UL) << (LO))
+#define BITMASK(HI, LO) (((1UL << ((HI) - (LO) + 1)) - 1UL) << (LO))
 #else
 #include <linux/bits.h>
+#define BITMASK(HI, LO) GENMASK(HI, LO)
 #endif
 
 #endif /* BITWISE_H */

--- a/src/lib/include/casemate-impl/bitwise.h
+++ b/src/lib/include/casemate-impl/bitwise.h
@@ -3,7 +3,7 @@
 
 #ifndef __KVM_NVHE_HYPERVISOR__
 #define BIT(I) (1UL << (I))
-#define GENMASK(L, S) (((1UL << (L)) - 1UL) << (S))
+#define GENMASK(HI, LO) (((1UL << ((HI) - (LO) + 1)) - 1UL) << (LO))
 #else
 #include <linux/bits.h>
 #endif

--- a/src/lib/include/casemate-impl/dummy_macros.h
+++ b/src/lib/include/casemate-impl/dummy_macros.h
@@ -1,8 +1,7 @@
 #ifndef CASEMATE_DUMMY_MACROS_H
 #define CASEMATE_DUMMY_MACROS_H
 
-#ifndef __KVM_NVHE_HYPERVISOR__
-
+#ifndef CONFIG_HAS_ASSERT
 #define GHOST_LOG_CONTEXT_ENTER()
 #define GHOST_LOG(NAME,TYPE)
 #define GHOST_LOG_CONTEXT_EXIT()
@@ -13,11 +12,6 @@
 #define GHOST_WARN(MSG) { \
 		ghost_printf(GHOST_WHITE_ON_YELLOW "%s" GHOST_NORMAL "\n", MSG); \
 	}
-
-#else
-
-#include <nvhe/ghost/ghost_context.h>
-
 #endif
 
 #endif /* CASEMATE_DUMMY_MACROS_H */

--- a/src/lib/include/casemate-impl/model.h
+++ b/src/lib/include/casemate-impl/model.h
@@ -5,7 +5,7 @@
 #include <casemate-impl/options.h>
 
 #define BLOB_SIZE ((1UL) << BLOB_SHIFT)
-#define BLOB_OFFSET_MASK GENMASK(BLOB_SHIFT, 0)
+#define BLOB_OFFSET_MASK BITMASK(BLOB_SHIFT - 1, 0)
 #define ALIGN_DOWN_TO_BLOB(x) ((x) & ~BLOB_OFFSET_MASK)
 #define OFFSET_IN_BLOB(x) ((x) & BLOB_OFFSET_MASK)
 #define SLOT_OFFSET_IN_BLOB(x) (OFFSET_IN_BLOB(x) >> SLOT_SHIFT)

--- a/src/lib/include/casemate-impl/pgtable.h
+++ b/src/lib/include/casemate-impl/pgtable.h
@@ -35,21 +35,21 @@
 #define PTE_FIELD_PKVM_OWNER_ID_GUEST (PKVM_ID_GUEST << PTE_FIELD_OWNER_ID_LO)
 
 #define PTE_FIELD_UPPER_ATTRS_LO 59
-#define PTE_FIELD_UPPER_ATTRS_MASK GENMASK(63, 50)
+#define PTE_FIELD_UPPER_ATTRS_MASK BITMASK(63, 50)
 
 #define PTE_FIELD_LOWER_ATTRS_LO 2
-#define PTE_FIELD_LOWER_ATTRS_MASK GENMASK(11, 2)
+#define PTE_FIELD_LOWER_ATTRS_MASK BITMASK(11, 2)
 
 #define PTE_FIELD_ATTRS_MASK (PTE_FIELD_UPPER_ATTRS_MASK | PTE_FIELD_LOWER_ATTRS_MASK)
 
 /* outside of realm security state, bit[55] is IGNORED, so can be used by software */
 #define PTE_FIELD_UPPER_ATTRS_SW_LO 55
-#define PTE_FIELD_UPPER_ATTRS_SW_MASK GENMASK(58, 55)
+#define PTE_FIELD_UPPER_ATTRS_SW_MASK BITMASK(58, 55)
 
-#define PTE_FIELD_TABLE_UPPER_IGNORED_MASK GENMASK(58, 51)
+#define PTE_FIELD_TABLE_UPPER_IGNORED_MASK BITMASK(58, 51)
 #define PTE_FIELD_TABLE_IGNORED_MASK (PTE_FIELD_LOWER_ATTRS_MASK | PTE_FIELD_TABLE_UPPER_IGNORED_MASK)
 
-#define PTE_FIELD_TABLE_NEXT_LEVEL_ADDR_MASK GENMASK(47,12)
+#define PTE_FIELD_TABLE_NEXT_LEVEL_ADDR_MASK BITMASK(47,12)
 
 #define PTE_FIELD_S1_AP2_LO 7
 #define PTE_FIELD_S1_AP2_MASK BIT(7)
@@ -65,10 +65,10 @@
 #define PTE_FIELD_S1_XN_EXEC_NEVER (1UL)
 
 #define PTE_FIELD_S1_ATTRINDX_LO 2
-#define PTE_FIELD_S1_ATTRINDX_MASK GENMASK(4, 2)
+#define PTE_FIELD_S1_ATTRINDX_MASK BITMASK(4, 2)
 
 #define PTE_FIELD_S2_S2AP10_LO 6
-#define PTE_FIELD_S2_S2AP10_MASK GENMASK(7, 6)
+#define PTE_FIELD_S2_S2AP10_MASK BITMASK(7, 6)
 
 #define PTE_FIELD_S2_S2AP0_LO 6
 #define PTE_FIELD_S2_S2AP0_MASK BIT(6)
@@ -81,7 +81,7 @@
 #define PTE_FIELD_S2_S2AP1_NOT_WRITEABLE (0UL)
 
 #define PTE_FIELD_S2_XN_LO 53
-#define PTE_FIELD_S2_XN_MASK GENMASK(54, 53)
+#define PTE_FIELD_S2_XN_MASK BITMASK(54, 53)
 /*
  * S2 XN is actually two bits encoding EL1 and EL0 execution separately.
  * but we assume they're either both allowed (00) or both forbidden (10)
@@ -90,7 +90,7 @@
 #define PTE_FIELD_S2_XN_EXEC_NEVER (0b10UL)
 
 #define PTE_FIELD_S2_MEMATTR_LO 2
-#define PTE_FIELD_S2_MEMATTR_MASK GENMASK(5, 2)
+#define PTE_FIELD_S2_MEMATTR_MASK BITMASK(5, 2)
 
 #define PTE_FIELD_S2_MEMATTR_DEVICE_nGnRE (0b0010UL)
 #define PTE_FIELD_S2_MEMATTR_NORMAL_OUTER_INNER_WRITE_BACK_CACHEABLE (0b1111UL)
@@ -118,19 +118,19 @@ typedef struct {
 
 #define TCR_TG0_LO 14
 #define TCR_TG0_WIDTH 2
-#define TCR_TG0_MASK (GENMASK(TCR_TG0_WIDTH - 1, 0) << TCR_TG0_LO)
+#define TCR_TG0_MASK (BITMASK(TCR_TG0_WIDTH - 1, 0) << TCR_TG0_LO)
 
 #define TCR_EL2_T0SZ_LO 0
 #define TCR_EL2_T0SZ_WIDTH 6
-#define TCR_EL2_T0SZ_MASK (GENMASK(TCR_EL2_T0SZ_WIDTH - 1, 0) << TCR_EL2_T0SZ_LO)
+#define TCR_EL2_T0SZ_MASK (BITMASK(TCR_EL2_T0SZ_WIDTH - 1, 0) << TCR_EL2_T0SZ_LO)
 
 /* outside of realm security state, bit[55] is IGNORED, so can be used by software */
 #define PTE_FIELD_UPPER_ATTRS_SW_LO 55
-#define PTE_FIELD_UPPER_ATTRS_SW_MASK GENMASK(58, 55)
+#define PTE_FIELD_UPPER_ATTRS_SW_MASK BITMASK(58, 55)
 
 /* Technically, MemAttr is not a PTE field, but actually stored in the MAIR_ELx register, but whatever */
 #define MEMATTR_LEN 8
-#define MEMATTR_MASK GENMASK(7,0)
+#define MEMATTR_MASK BITMASK(7,0)
 #define EXTRACT_MEMATTR(MAIR, IDX) (((MAIR) >> ((IDX) * MEMATTR_LEN)) & MEMATTR_MASK)
 #define MEMATTR_FIELD_DEVICE_nGnRE (0b00000100UL)
 #define MEMATTR_FIELD_NORMAL_OUTER_INNER_WRITE_BACK_CACHEABLE (0b11111111)
@@ -167,8 +167,8 @@ struct aal {
 
 #define DUMMY_AAL ((struct aal){.attr_at_level={0}})
 
-#define TTBR_BADDR_MASK	GENMASK(47, 1)
-#define TTBR_ID_MASK GENMASK(63, 48)
+#define TTBR_BADDR_MASK	BITMASK(47, 1)
+#define TTBR_ID_MASK BITMASK(63, 48)
 
 static inline phys_addr_t ttbr_extract_baddr(u64 vttb)
 {
@@ -180,9 +180,9 @@ static inline u64 ttbr_extract_id(u64 ttb)
 	return ttb & TTBR_ID_MASK;
 }
 
-#define TLBI_PAGE_MASK	GENMASK(43, 0)
-#define TLBI_ASID_MASK	GENMASK(63, 48)
-#define TLBI_TTL_MASK	GENMASK(47, 44)
+#define TLBI_PAGE_MASK	BITMASK(43, 0)
+#define TLBI_ASID_MASK	BITMASK(63, 48)
+#define TLBI_TTL_MASK	BITMASK(47, 44)
 
 bool is_desc_table(u64 descriptor, u64 level, entry_stage_t stage);
 bool is_desc_valid(u64 descriptor);

--- a/src/lib/include/casemate-impl/pgtable.h
+++ b/src/lib/include/casemate-impl/pgtable.h
@@ -168,6 +168,7 @@ struct aal {
 #define DUMMY_AAL ((struct aal){.attr_at_level={0}})
 
 #define TTBR_BADDR_MASK	BITMASK(47, 1)
+#define TTBR_ID_LO 48UL
 #define TTBR_ID_MASK BITMASK(63, 48)
 
 static inline phys_addr_t ttbr_extract_baddr(u64 vttb)
@@ -177,7 +178,7 @@ static inline phys_addr_t ttbr_extract_baddr(u64 vttb)
 
 static inline u64 ttbr_extract_id(u64 ttb)
 {
-	return ttb & TTBR_ID_MASK;
+	return (ttb & TTBR_ID_MASK) >> TTBR_ID_LO;
 }
 
 #define TLBI_PAGE_MASK	BITMASK(43, 0)

--- a/src/lib/include/casemate-impl/platform.h
+++ b/src/lib/include/casemate-impl/platform.h
@@ -1,0 +1,8 @@
+#ifndef CASEMATE_PLATFORM_H
+#define CASEMATE_PLATFORM_H
+
+#ifdef __KVM_NVHE_HYPERVISOR__
+#include <casemate-impl/platform/linux.h>
+#endif
+
+#endif /* CASEMATE_PLATFORM_H */

--- a/src/lib/include/casemate-impl/platform/linux.h
+++ b/src/lib/include/casemate-impl/platform/linux.h
@@ -1,0 +1,25 @@
+#ifndef CASEMATE_LINUX_H
+#define CASEMATE_LINUX_H
+
+#ifdef __KVM_NVHE_HYPERVISOR__
+#endif
+
+#include <linux/bits.h>
+
+#include <nvhe/ghost/ghost_context.h>
+#include <nvhe/ghost/ghost_asserts.h>
+
+#define GHOST_MODEL_CATCH_FIRE(msg) { \
+	ensure_traced_current_transition(true); \
+	GHOST_WARN(msg); \
+	ghost_assert(false); \
+}
+
+#define BITMASK(HI, LO) GENMASK(HI, LO)
+
+#define CONFIG_HAS_BITWISE
+#define CONFIG_HAS_ASSERT
+#define CONFIG_HAS_PRINTF
+#define CONFIG_HAS_STRLEN
+
+#endif /* CASEMATE_LINUX_H */

--- a/src/lib/include/casemate-impl/types.h
+++ b/src/lib/include/casemate-impl/types.h
@@ -1,13 +1,8 @@
 #ifndef CASEMATE_TYPES_H
 #define CASEMATE_TYPES_H
 
-#ifndef __KVM_NVHE_HYPERVISOR__
-
 #ifndef NULL
 #define NULL ((void*)0)
 #endif
-
-#endif
-
 
 #endif /* CASEMATE_TYPES_H */

--- a/src/lib/src/pgtable.c
+++ b/src/lib/src/pgtable.c
@@ -5,7 +5,7 @@
 
 #define PTE_BIT_VALID BIT(0)
 #define PTE_BIT_TABLE BIT(1)
-#define PTE_BITS_TABLE_POINTER GENMASK(47, 12)
+#define PTE_BITS_TABLE_POINTER BITMASK(47, 12)
 #define PTE_BIT_OA_MSB 47
 
 #define KiB_SHIFT 10ULL
@@ -28,9 +28,9 @@ static const u64 MAP_SIZES[] = {
 // DS is for 52-bit output addressing with FEAT_LPA2, and is zero in the register values we see; I'll hard-code that for now.  Thus, G.b says:
 // - For a level 1 Block descriptor, bits[47:30] are bits[47:30] of the output address. This output address specifies a 1GB block of memory.
 // - For a level 2 Block descriptor, bits[47:21] are bits[47:21] of the output address.This output address specifies a 2MB block of memory.
-#define PTE_FIELD_LVL1_OA_MASK GENMASK(47, 30)
-#define PTE_FIELD_LVL2_OA_MASK GENMASK(47, 21)
-#define PTE_FIELD_LVL3_OA_MASK GENMASK(47, 12)
+#define PTE_FIELD_LVL1_OA_MASK BITMASK(47, 30)
+#define PTE_FIELD_LVL2_OA_MASK BITMASK(47, 21)
+#define PTE_FIELD_LVL3_OA_MASK BITMASK(47, 12)
 
 static u64 PTE_FIELD_OA_MASK[4] = {
 	[1] = PTE_FIELD_LVL1_OA_MASK,

--- a/src/lib/src/utilities/printer.c
+++ b/src/lib/src/utilities/printer.c
@@ -116,7 +116,7 @@ int sb_putxn(struct string_builder *buf, u64 x, u32 n)
 //////////
 // Printf
 
-#ifndef __KVM_NVHE_HYPERVISOR__
+#ifndef CONFIG_HAS_PRINTF
 int ghost_printf(const char *fmt, ...)
 {
 	int ret;
@@ -132,7 +132,7 @@ int ghost_printf(const char *fmt, ...)
 
 	return ret;
 }
-#endif /* __KVM_NVHE_HYPERVISOR__ */
+#endif /* CONFIG_HAS_PRINTF */
 
 int ghost_fprintf(void *arg, const char *fmt, ...)
 {

--- a/src/lib/src/utilities/string.c
+++ b/src/lib/src/utilities/string.c
@@ -1,6 +1,6 @@
 #include <casemate-impl.h>
 
-#ifndef __KVM_NVHE_HYPERVISOR__
+#ifndef CONFIG_HAS_STRLEN
 u64 strlen(const char *s) {
 	u64 i = 0;
 
@@ -11,7 +11,7 @@ u64 strlen(const char *s) {
 
 	return i;
 }
-#endif /* __KVM_NVHE_HYPERVISOR__ */
+#endif /* CONFIG_HAS_STRLEN */
 
 bool streq(const char *s1, const char *s2) {
 	if (*s1 == '\0')


### PR DESCRIPTION
We pull in a Linux header when compiling as part of KVM, which defines a `GENMASK` macro.
Our alternative GENMASK macro was similar, but had slighly different semantics.

This makes a brand new macro, `BITWISE()` with a consistent semantics, regardless of whether built-in to KVM or standalone.

It then pulls out the more nested Linux-y ifdefs to a top-level platform.h, which exposes them all uniformly.