### PR TITLE
(lib) move globals into state

### DIFF
--- a/src/lib/casemate.h
+++ b/src/lib/casemate.h
@@ -312,6 +312,15 @@ int initialise_casemate_model(struct casemate_options *opts, uint64_t phys, uint
 			      void *sm_virt, uint64_t sm_size);
 
 /**
+ * attach_casemate_model() - Attach monitor to a running model state
+ * @st: the start of the virtual address of the memory the ghost model state is at
+ *
+ * Returns -1 if the pointed to state is not properly initialised
+ * Returns 0 otherwise
+ */
+int attach_casemate_model(void *st);
+
+/**
  * casemate_cpu_id() - Return current CPU identifier.
  *
  * Users should implement this if they want to use the helper macros.

--- a/src/lib/include/casemate-impl/bitwise.h
+++ b/src/lib/include/casemate-impl/bitwise.h
@@ -6,4 +6,7 @@
 #define BITMASK(HI, LO) (((1UL << ((HI) - (LO) + 1)) - 1UL) << (LO))
 #endif /* CONFIG_HAS_BITWISE */
 
+/* align to a power of 2 boundary */
+#define ALIGN_UP_TO(V, A) (V) + (((A)-1) & (1 + ((V) ^ -1)))
+
 #endif /* BITWISE_H */

--- a/src/lib/include/casemate-impl/options.h
+++ b/src/lib/include/casemate-impl/options.h
@@ -3,16 +3,11 @@
 
 #include <casemate.h>
 
-extern struct casemate_options sm_options;
-
 #define CASEMATE_MAX_WATCHPOINTS 16
 struct casemate_watchpoints {
 	u64 num_watchpoints;
 	u64 watchpoints[CASEMATE_MAX_WATCHPOINTS];
 };
-
-extern struct casemate_watchpoints sm_watchpoints;
-extern bool touched_watchpoint;
 
 /**
  * opts() - Get model options.

--- a/src/lib/include/casemate-impl/state.h
+++ b/src/lib/include/casemate-impl/state.h
@@ -2,6 +2,7 @@
 #define CASEMATE_STATE_H
 
 #include <casemate-impl/types.h>
+#include <casemate-impl/sync.h>
 
 /*
  * Model types
@@ -432,5 +433,42 @@ struct casemate_model_state {
 };
 
 int ghost_dump_model_state(void *arg, struct casemate_model_state *st);
+
+/**
+ * struct casemate_state - Top-level casemate state
+ */
+struct casemate_state {
+	sm_mtx_t sm_lock;
+
+	bool is_initialised;
+	struct casemate_options opts;
+	struct ghost_driver driver;
+
+	/**
+	 * current_transition - The step currently being executed.
+	 */
+	struct casemate_model_step current_transition;
+
+	/**
+	 * traced_current_trans - Whether the current step has been traced so far 
+	 */
+	bool traced_current_trans;
+
+	/**
+	 * transition_id - The sequence ID to give to the next transition.
+	 */
+	u64 transition_id;
+
+	bool touched_watchpoint;
+	struct casemate_watchpoints watchpoints;
+
+	struct casemate_model_state *st;
+	struct casemate_model_state *st_pre;
+};
+
+extern struct casemate_state *the_ghost_state;
+#define STATE() the_ghost_state
+#define MODEL() STATE()->st
+#define CURRENT_TRANS() STATE()->current_transition
 
 #endif /* CASEMATE_STATE_H */

--- a/src/lib/include/casemate-impl/string.h
+++ b/src/lib/include/casemate-impl/string.h
@@ -1,6 +1,10 @@
 #ifndef CASEMATE_STRING_H
 #define CASEMATE_STRING_H
 
+#include <casemate-impl/types.h>
+
+u64 strlen(const char *s);
 bool streq(const char *s1, const char *s2);
+void *memset(void *ptr, int value, u64 num);
 
 #endif /* CASEMATE_STRING_H */

--- a/src/lib/include/casemate-impl/sync.h
+++ b/src/lib/include/casemate-impl/sync.h
@@ -1,6 +1,17 @@
 #ifndef CASEMATE_SYNC_H
 #define CASEMATE_SYNC_H
 
+#if defined(__AARCH64__)
+typedef struct mutex {
+	u64 locked;
+} sm_mtx_t;
+#elif defined(__X86__)
+#include <threads.h>
+typedef mtx_t sm_mtx_t;
+#else
+#error REQUIRES_CONFIGURE_WITH_AN_ARCHITECTURE
+#endif
+
 void init_sm_lock(void);
 void lock_sm(void);
 void unlock_sm(void);

--- a/src/lib/include/casemate-in/casemate-transitions.in.h
+++ b/src/lib/include/casemate-in/casemate-transitions.in.h
@@ -104,6 +104,15 @@ int initialise_casemate_model(struct casemate_options *opts, uint64_t phys, uint
 			      void *sm_virt, uint64_t sm_size);
 
 /**
+ * attach_casemate_model() - Attach monitor to a running model state
+ * @st: the start of the virtual address of the memory the ghost model state is at
+ *
+ * Returns -1 if the pointed to state is not properly initialised
+ * Returns 0 otherwise
+ */
+int attach_casemate_model(void *st);
+
+/**
  * casemate_cpu_id() - Return current CPU identifier.
  *
  * Users should implement this if they want to use the helper macros.

--- a/src/lib/src/pgtable.c
+++ b/src/lib/src/pgtable.c
@@ -387,18 +387,17 @@ void traverse_pgtable(u64 root, entry_stage_t stage, pgtable_traverse_cb visitor
 void add_location_to_unclean_PTE(struct sm_location *loc)
 {
 	// Check that the location is not already in the set
-	for (int i = 0; i < the_ghost_state->unclean_locations.len; i++) {
-		if (loc == the_ghost_state->unclean_locations.locations[i]) {
+	for (int i = 0; i < MODEL()->unclean_locations.len; i++) {
+		if (loc == MODEL()->unclean_locations.locations[i]) {
 			GHOST_WARN("A location was added twice to the unclean PTEs");
 			ghost_assert(false);
 		}
 	}
 
 	// Add it to the set
-	ghost_assert(the_ghost_state->unclean_locations.len < MAX_UNCLEAN_LOCATIONS);
-	the_ghost_state->unclean_locations.locations[the_ghost_state->unclean_locations.len] =
-		loc;
-	the_ghost_state->unclean_locations.len++;
+	ghost_assert(MODEL()->unclean_locations.len < MAX_UNCLEAN_LOCATIONS);
+	MODEL()->unclean_locations.locations[MODEL()->unclean_locations.len] = loc;
+	MODEL()->unclean_locations.len++;
 }
 
 static struct pgtable_traverse_context construct_context_from_pte(struct sm_location *loc,
@@ -423,11 +422,11 @@ static struct pgtable_traverse_context construct_context_from_pte(struct sm_loca
 void traverse_all_unclean_PTE(pgtable_traverse_cb visitor_cb, void *data, entry_stage_t stage)
 {
 	struct sm_location *loc;
-	u64 *len = &the_ghost_state->unclean_locations.len;
+	u64 *len = &MODEL()->unclean_locations.len;
 	struct pgtable_traverse_context ctx;
 
 	for (int i = 0; i < *len; i++) {
-		loc = the_ghost_state->unclean_locations.locations[i];
+		loc = MODEL()->unclean_locations.locations[i];
 
 		ghost_assert(loc->initialised);
 		ghost_assert(loc->is_pte);
@@ -445,8 +444,8 @@ void traverse_all_unclean_PTE(pgtable_traverse_cb visitor_cb, void *data, entry_
 		if (loc->state.kind != STATE_PTE_INVALID_UNCLEAN) {
 			// Take the last location of the list and put it in the current cell
 			(*len)--;
-			the_ghost_state->unclean_locations.locations[i] =
-				the_ghost_state->unclean_locations.locations[*len];
+			MODEL()->unclean_locations.locations[i] =
+				MODEL()->unclean_locations.locations[*len];
 			// decrement i to run on the current cell
 			i--;
 		}


### PR DESCRIPTION
Move globals into a global state
Enables multiple monitors to attach to the same shared state